### PR TITLE
fix(postId.js): fix postId.js page error not found

### DIFF
--- a/pages/posts/[postId].js
+++ b/pages/posts/[postId].js
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { BsHeartFill, BsHeart } from "react-icons/bs";
-import AvatarCollection from "../../../components/AvatarCollection";
+import AvatarCollection from "../../components/AvatarCollection";
 import {
   Box,
   Center,


### PR DESCRIPTION
On Vercel, searching for the route `posts/postId` will result in 404 error not found.