### PR TITLE
feat(PostOptionsMenu.js): add delete, edit options to single post page

### DIFF
--- a/components/PostOptionsMenu.js
+++ b/components/PostOptionsMenu.js
@@ -1,0 +1,26 @@
+import {
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  IconButton,
+} from "@chakra-ui/react";
+import { HiDotsVertical } from "react-icons/hi";
+
+export default function PostOptionsMenu() {
+  return (
+    <Menu>
+      <MenuButton
+        as={IconButton}
+        aria-label="Options"
+        icon={<HiDotsVertical />}
+        variant="ghost"
+        rounded="100"
+      />
+      <MenuList>
+        <MenuItem>Edit Post</MenuItem>
+        <MenuItem textColor="red.500">Delete Post</MenuItem>
+      </MenuList>
+    </Menu>
+  );
+}

--- a/pages/posts/[postId]/index.js
+++ b/pages/posts/[postId]/index.js
@@ -18,7 +18,7 @@ import { useState } from "react";
 import { useRouter as router } from "next/dist/client/router";
 import { useTranslation } from "next-i18next";
 import PostOptionsMenu from "../../../components/PostOptionsMenu";
-
+//test
 export default function Index() {
   const { t } = useTranslation("postId");
   const [joinBtn, setJoinBtn] = useState(false);

--- a/pages/posts/[postId]/index.js
+++ b/pages/posts/[postId]/index.js
@@ -17,10 +17,12 @@ import {
 import { useState } from "react";
 import { useRouter as router } from "next/dist/client/router";
 import { useTranslation } from "next-i18next";
+import PostOptionsMenu from "../../../components/PostOptionsMenu";
 
 export default function Index() {
   const { t } = useTranslation("postId");
   const [joinBtn, setJoinBtn] = useState(false);
+  const [isPostOwner, setIsPostOwner] = useState(true);
   const [liked, setLiked] = useState(false);
   return (
     <Center p="6" dir={router().locale === "ar" ? "rtl" : "ltr"}>
@@ -41,6 +43,7 @@ export default function Index() {
             <Button rounded="15px" onClick={() => setJoinBtn(!joinBtn)}>
               {joinBtn ? t("joined") : t("join")}
             </Button>
+            {isPostOwner ? <PostOptionsMenu /> : null}
           </HStack>
           <AvatarCollection users={usersDummyData} />
 

--- a/pages/posts/[postId]/index.js
+++ b/pages/posts/[postId]/index.js
@@ -18,7 +18,6 @@ import { useState } from "react";
 import { useRouter as router } from "next/dist/client/router";
 import { useTranslation } from "next-i18next";
 import PostOptionsMenu from "../../../components/PostOptionsMenu";
-//test2
 export default function Index() {
   const { t } = useTranslation("postId");
   const [joinBtn, setJoinBtn] = useState(false);

--- a/pages/posts/[postId]/index.js
+++ b/pages/posts/[postId]/index.js
@@ -18,7 +18,7 @@ import { useState } from "react";
 import { useRouter as router } from "next/dist/client/router";
 import { useTranslation } from "next-i18next";
 import PostOptionsMenu from "../../../components/PostOptionsMenu";
-//test
+//test2
 export default function Index() {
   const { t } = useTranslation("postId");
   const [joinBtn, setJoinBtn] = useState(false);


### PR DESCRIPTION
## What?
Added a menu button to the single post page.
## Why?
Post owners now can edit or delete their posts
## How to use?
go to route `/posts/anything`